### PR TITLE
Fix test environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: alpine:3.7
+      - image: ubuntu:16.04
     steps:
       - checkout
       - run:  chmod -R +x *.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,5 +6,6 @@ jobs:
     steps:
       - checkout
       - run:  chmod -R +x *.sh
+      - run:  apt-get update && apt-get install -y git
       - run:  git clone https://github.com/sstephenson/bats.git && cd bats && ./install.sh /usr/local
       - run:  test/runTests.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,9 @@ version: 2
 jobs:
   build:
     docker:
-      - image: dduportal/bats
+      - image: alpine:3.7
     steps:
       - checkout
       - run:  chmod -R +x *.sh
+      - run:  git clone https://github.com/sstephenson/bats.git && cd bats && ./install.sh /usr/local
       - run:  test/runTests.sh

--- a/generate.sh
+++ b/generate.sh
@@ -62,7 +62,7 @@ while read -r f ; do
     command="\\lstinputlisting[${langString}label={lst:${label}}, caption={${caption}}]{${f}}"
     commands+=("${command}")
 
-done <<< ${files}
+done <<< "${files}"
 
 commands_as_string=$( IFS=$'\n'; echo "${commands[*]}" )
 


### PR DESCRIPTION
Other images uses busybox version of `find` which doesn't have parameter 'regextype'.
Changing image to Ubuntu for GNU version of `find` and ensuring found files are line separated fixed issue.